### PR TITLE
Change PostgreSQL version from 9.3 to 9.5

### DIFF
--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -25,7 +25,7 @@ class Backup
       opt :disable,               "Disable paths with -d name",                              :type => :strings
       opt :no_db,                 "Disable database backup"
       opt :landscape_prefix,      "Path to prefix default landscape dirs (/var, /etc) with", :default => "/"
-      opt :no_op,                 "No-op (dry run)",
+      opt :no_op,                 "No-op (dry run)"
       opt :sudo,                  "Program to use as sudo",                                  :default => "sudo"
       opt :x509_certificate,      "Path to landscape x509 certificate",                      :type => String
       opt :ca_certificate,        "Path to landscape CA certificatess" ,                     :type => String

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -25,16 +25,16 @@ class Backup
       opt :disable,               "Disable paths with -d name",                              :type => :strings
       opt :no_db,                 "Disable database backup"
       opt :landscape_prefix,      "Path to prefix default landscape dirs (/var, /etc) with", :default => "/"
-      opt :no_op,                 "No-op (dry run)"
+      opt :no_op,                 "No-op (dry run)",
       opt :sudo,                  "Program to use as sudo",                                  :default => "sudo"
       opt :x509_certificate,      "Path to landscape x509 certificate",                      :type => String
-      opt :ca_certificate,        "Path to landscape CA certificatess"                       :type => String
-      opt :ssl_private_key,       "Path to Landscape's private key"                          :type => String
-      opt :postgresql_config      "Path to landscape's Postgresql config"                    :type => String
-      opt :apache_config          "Path to Apache config"                                    :type => String
-      opt :hash_id_database       "Path to Hash ID databases"                                :type => String
-      opt :landscape_dir          "Path to landscape directory"                              :type => String
-      opt :landscape_default      "Path to default landscape server directory"               :type => String
+      opt :ca_certificate,        "Path to landscape CA certificatess" ,                     :type => String
+      opt :ssl_private_key,       "Path to Landscape's private key",                         :type => String
+      opt :postgresql_config,     "Path to landscape's Postgresql config",                   :type => String
+      opt :apache_config,         "Path to Apache config",                                   :type => String
+      opt :hash_id_database,      "Path to Hash ID databases",                               :type => String
+      opt :landscape_dir,         "Path to landscape directory",                             :type => String
+      opt :landscape_default,     "Path to default landscape server directory",              :type => String
       banner <<-USAGE
 To override specific paths, use -o name1=path1 -o name2=path2 -o name3=path3
 To disable specific paths for backup, use -d name1 -d name2

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -36,12 +36,10 @@ class Backup
       opt :landscape_dir,         "Path to landscape directory",                             :type => String
       opt :landscape_default,     "Path to default landscape server directory",              :type => String
       banner <<-USAGE
-To override specific paths, use -o name1=path1 -o name2=path2 -o name3=path3
+To override specific paths, use the optional arguments for the different paths listed above.
 To disable specific paths for backup, use -d name1 -d name2
 Overrides have higher priority than --landscape-prefix.
 
-Names with default values:
-#{paths.keys.map { |k| "  #{k}: #{paths[k]}"} }
       USAGE
     end
 

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -50,8 +50,12 @@ Overrides have higher priority than --landscape-prefix.
    path_args = new_args.clone
    [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo, :help].each { |k| path_args.delete(k) }
    (path_args.keys).each do |o|
-     raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
-     paths[o] = path_args[o]
+     if !o.to_s.include?("_given")
+       if path_args["#{o}_given".to_sym] == true
+         raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
+         paths[o] = path_args[o]
+       end
+     end
    end 
  
     (new_args[:disable] || []).each do |d|

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -27,7 +27,14 @@ class Backup
       opt :landscape_prefix,      "Path to prefix default landscape dirs (/var, /etc) with", :default => "/"
       opt :no_op,                 "No-op (dry run)"
       opt :sudo,                  "Program to use as sudo",                                  :default => "sudo"
-
+      opt :x509_certificate,      "Path to landscape x509 certificate",                      :type => String
+      opt :ca_certificate,        "Path to landscape CA certificatess"                       :type => String
+      opt :ssl_private_key,       "Path to Landscape's private key"                          :type => String
+      opt :postgresql_config      "Path to landscape's Postgresql config"                    :type => String
+      opt :apache_config          "Path to Apache config"                                    :type => String
+      opt :hash_id_database       "Path to Hash ID databases"                                :type => String
+      opt :landscape_dir          "Path to landscape directory"                              :type => String
+      opt :landscape_default      "Path to default landscape server directory"               :type => String
       banner <<-USAGE
 To override specific paths, use -o name1=path1 -o name2=path2 -o name3=path3
 To disable specific paths for backup, use -d name1 -d name2

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -12,7 +12,7 @@ class Backup
       :x509_certificate  => "/etc/ssl/certs/landscape_server.pem",
       :ca_certificate    => "/etc/ssl/certs/landscape_server_ca.crt",
       :ssl_private_key   => "/etc/ssl/private/landscape_server.key",
-      :postgresql_config => "/etc/postgresql/9.4/main",
+      :postgresql_config => "/etc/postgresql/9.5/main",
       :apache_config     => "/etc/apache2/sites-available/landscape-server.conf",
       :hash_id_database  => "/var/lib/landscape/hash-id-databases",
       :landscape_dir     => "/etc/landscape",

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -53,7 +53,7 @@ Names with default values:
    path_args = new_args.clone
    [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo].each { |k| path_args.delete(k) }
    (path_args || []).each do |o|
-     raise "Unrecognized path  argument: #{key.inspect}!" unless paths[o]
+     raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
      paths[o] = path_args[o]
    end 
  

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -39,7 +39,6 @@ class Backup
 To override specific paths, use the optional arguments for the different paths listed above.
 To disable specific paths for backup, use -d name1 -d name2
 Overrides have higher priority than --landscape-prefix.
-
       USAGE
     end
 
@@ -49,7 +48,7 @@ Overrides have higher priority than --landscape-prefix.
     paths.each { |k, v| paths[k] = "#{prefix}#{v}" }
 
    path_args = new_args.clone
-   [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo].each { |k| path_args.delete(k) }
+   [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo, :help!].each { |k| path_args.delete(k) }
    (path_args.keys).each do |o|
      raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
      paths[o] = path_args[o]

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -12,7 +12,7 @@ class Backup
       :x509_certificate  => "/etc/ssl/certs/landscape_server.pem",
       :ca_certificate    => "/etc/ssl/certs/landscape_server_ca.crt",
       :ssl_private_key   => "/etc/ssl/private/landscape_server.key",
-      :postgresql_config => "/etc/postgresql/9.3/main",
+      :postgresql_config => "/etc/postgresql/9.4/main",
       :apache_config     => "/etc/apache2/sites-available/landscape-server.conf",
       :hash_id_database  => "/var/lib/landscape/hash-id-databases",
       :landscape_dir     => "/etc/landscape",

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -48,7 +48,7 @@ Overrides have higher priority than --landscape-prefix.
     paths.each { |k, v| paths[k] = "#{prefix}#{v}" }
 
    path_args = new_args.clone
-   [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo, :help!].each { |k| path_args.delete(k) }
+   [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo, :help].each { |k| path_args.delete(k) }
    (path_args.keys).each do |o|
      raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
      paths[o] = path_args[o]

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -43,13 +43,13 @@ Names with default values:
     prefix = new_args[:landscape_prefix]
     paths.each { |k, v| paths[k] = "#{prefix}#{v}" }
 
-    (new_args[:override] || []).each do |o|
-      key, val = o.split("=")
-      key = key.to_sym
-      raise "Unrecognized name argument: #{key.inspect}!" unless paths[key]
-      paths[key] = val
-    end
-
+   path_args = new_args.clone
+   [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo].each { |k| path_args.delete(k) }
+   (path_args || []).each do |o|
+     raise "Unrecognized path  argument: #{key.inspect}!" unless paths[o]
+     paths[o] = path_args[o]
+   end 
+ 
     (new_args[:disable] || []).each do |d|
       raise "Unrecognized name argument: #{d.inspect}!" unless paths[key]
       paths.delete d.to_sym

--- a/lib/landscape-turner/backup.rb
+++ b/lib/landscape-turner/backup.rb
@@ -50,7 +50,7 @@ Overrides have higher priority than --landscape-prefix.
 
    path_args = new_args.clone
    [:snapshot_path, :override, :disable, :no_db, :landscape_prefix, :no_op, :sudo].each { |k| path_args.delete(k) }
-   (path_args || []).each do |o|
+   (path_args.keys).each do |o|
      raise "Unrecognized path  argument: #{o.inspect}!" unless paths[o]
      paths[o] = path_args[o]
    end 

--- a/lib/landscape-turner/restore.rb
+++ b/lib/landscape-turner/restore.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 
 class Restore
   extend LandscapeTurner::Helpers
-  POSTGRES_CONFIG = "/etc/postgresql/9.3/main"
+  POSTGRES_CONFIG = "/etc/postgresql/9.5/main"
   EXCLUDE_FILES = [POSTGRES_CONFIG]
   def self.restore_with_cli_args(args = ARGV)
     opts = Trollop.options(args) do


### PR DESCRIPTION
Rong recently told me our landscape servers use version 9.5 instead of 9.3 (the version at the time from when we were development) This updates the path folder to the latest version so it can work again but it would be nice to have a small yaml file turner reads from that would contain the version that the user could simply edit.